### PR TITLE
fix anchor tag never closed

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -15,14 +15,14 @@
 	{{#author}}
 		<section class="author-card cf">
 			<div class="author-meta">
-				 {{#if name}}<a class="author-name" href="{{url}}">{{name}}</span>{{/if}}
+				 {{#if name}}<a class="author-name" href="{{url}}">{{name}}</a>{{/if}}
 				 {{#if website}}<a href="{{website}}" class="author-website" rel="author">Website</a>{{/if}}
 				 {{#if location}}<div class="author-location">{{location}}</div>{{/if}}
 				 {{#if bio}}<p class="author-bio">{{{bio}}}</p>{{/if}}
 			</div>
 		</section>
 	{{/author}}
-	
+
 	{{navigation}}
 </header>
 
@@ -38,14 +38,14 @@
 			<h2 class="post-title"><a href="{{url}}">{{title}}</a></h2>
 			<a class="post-meta" href="{{url}}">Posted on <time datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMMM YYYY"}}</time></a>
 		</header>
-		
+
 		<section class="post-excerpt">
 			<p>{{excerpt}}<a href="{{url}}" class="excerpt-suffix">&hellip;</a></p>
 		</section>
-		
+
 		<footer class="post-footer">
 			<div class="post-tags">{{tags separator=", " prefix="Tagged with: "}}</div>
-		</footer> 
+		</footer>
 	</article>
 
 	{{/foreach}}

--- a/post.hbs
+++ b/post.hbs
@@ -5,7 +5,7 @@
 	{{#if @blog.logo}}<a href="{{@blog.url}}"><img class="blog-logo" src="{{@blog.logo}}" alt="Blog Logo" /></a>{{/if}}
 	{{#if @blog.title}}<h1 class="blog-title"><a href="{{@blog.url}}">{{@blog.title}}</a></h1>{{/if}}
 	{{#if @blog.description}}<h2 class="blog-description">{{@blog.description}}</h2>{{/if}}
-	
+
 	{{navigation}}
 </header>
 
@@ -14,7 +14,7 @@
 <main class="site-content" role="main">
 
 	<article class="{{post_class}}">
-			
+
 			{{! Add Open Graph tags to head}}
 			{{#contentFor "meta"}}
 				<meta property="og:description" content="{{excerpt characters="220"}}...">
@@ -36,12 +36,12 @@
 				{{#author}}
 					<section class="author-card cf">
 						{{#if image}}
-							<figure class="author-image">					
+							<figure class="author-image">
 								<a href="{{url}}"><img src="{{image}}" alt="{{name}}'s Image"></a>
 							</figure>
 						{{/if}}
 						<div class="author-meta" {{#if author.image}}style="width: 65%; float: left;"{{/if}}>
-							 {{#if name}}<a class="author-name" href="{{url}}">{{name}}</span>{{/if}}
+							 {{#if name}}<a class="author-name" href="{{url}}">{{name}}</a>{{/if}}
 							 {{#if website}}<a href="{{website}}" class="author-website" rel="author">Website</a>{{/if}}
 							 {{#if location}}<div class="author-location">{{location}}</div>{{/if}}
 							 {{#if bio}}<p class="author-bio">{{{bio}}}</p>{{/if}}
@@ -54,7 +54,7 @@
 				{{/if}}
 			</footer>
 	</article>
-	
+
 	<aside class="post-navigation cf">
 		{{#next_post}}
 			<div class="nav-next">


### PR DESCRIPTION
On line 44 in post.hbs anchor tag is never closed which screws styling when user doesn't provide website url because anchor tag will never be closed and it will mess up author info styling as well as previous/next arrows bellow. Same thing in author.hbs.

If website info is provided anchor tag will be closed in that line which is why it works in your demo.

The rest is just automatic removal of spaces.