### PR TITLE
Pulling in Koenig image gallery css/js from Casper

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -211,6 +211,40 @@
 	margin-right: 0.25em;
 }
 
+.kg-image-card,
+.kg-gallery-card {
+    margin: 0 0 1.5em;
+}
+
+.kg-image-card figcaption,
+.kg-gallery-card figcaption {
+    margin: -1.0em 0 1.5em;
+}
+
+.kg-gallery-container {
+    display: flex;
+    flex-direction: column;
+    margin: 1.5em auto;
+    width: 100vw;
+}
+.kg-gallery-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+.kg-gallery-image img {
+    display: block;
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+.kg-gallery-row:not(:first-of-type) {
+    margin: 0.75em 0 0 0;
+}
+.kg-gallery-image:not(:first-of-type) {
+    margin: 0 0 0 0.75em;
+}
+
 figure.kg-embed-card {
 	margin: 0.5rem auto;
 	

--- a/default.hbs
+++ b/default.hbs
@@ -51,6 +51,17 @@
 
 </div> {{! end .site-main }}
 {{#if @blog.logo}}</div> {{! end .page-scroll }} {{/if}}
+	
+	<script>
+        var images = document.querySelectorAll('.kg-gallery-image img');
+        images.forEach(function (image) {
+            var container = image.closest('.kg-gallery-image');
+            var width = image.attributes.width.value;
+            var height = image.attributes.height.value;
+            var ratio = width / height;
+            container.style.flex = ratio + ' 1 0%';
+        })
+    </script>
 
 	{{! Ghost outputs important scripts and data with this tag }}
 	{{ghost_foot}}


### PR DESCRIPTION
When working with Ghost 2.7, the validator asks for several
CSS classes to be present. I pulled the classes and JavaScript
from the Casper theme to stay compliant, and made slight modifications to work with this theme.

Only affects the "gallery" type embed, and seems to work well with
testing.