### PR TITLE
Remove role="pagination"

### DIFF
--- a/partials/pagination.hbs
+++ b/partials/pagination.hbs
@@ -1,4 +1,4 @@
-<nav class="pagination" role="pagination">
+<nav class="pagination">
      <span class="page-number">{{t "Page"}} {{page}} {{t "of"}} {{pages}}</span>
     
     <nav class="page-nav cf">


### PR DESCRIPTION
role="pagination" is not valid according to ARIA, remove it to reduce warnings from Lighthouse. 
Related: https://dequeuniversity.com/rules/axe/2.2/aria-roles

I'll admit, I'm not sure what this might have been getting used for but, with 0.9.2 installed + this change, https://techsmix.net/ not longer flags it during a Lighthouse audit. I figured I should open this upstream for your thoughts as well. 